### PR TITLE
Replaced: Polyfill

### DIFF
--- a/api-docs/_templates/scripts.html
+++ b/api-docs/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
@the2hill 

GitHub: https://developer.rackspace.com/docs/cloud-queues/v1/developer-guide/ is not mapping correctly, it lands to 404 error page. In Readme.io. there is an external link: https://docs-ospc.rackspace.com/cloud-queues/v1/

Could you please review and merge PR. 